### PR TITLE
Update the stability function

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.github$

--- a/R/evaluate-clusters.R
+++ b/R/evaluate-clusters.R
@@ -208,15 +208,17 @@ calculate_stability <- function(
   # ensure we have a matrix
   pca_matrix <- prepare_pc_matrix(x, pc_name = pc_name)
 
+  # ensure pca matrix and cluster df compatibility
+  stopifnot(
+    "The cluster dataframe must have the same number of rows as the PCA matrix." =
+      nrow(pca_matrix) == nrow(cluster_df),
+    "Cell ids in the cluster dataframe must match the PCA matrix rownames." =
+      length(setdiff(rownames(pca_matrix), cluster_df$cell_id)) == 0
+  )
+
   # Extract vector of clusters, ensuring same order as pca_matrix
   rownames(cluster_df) <- cluster_df$cell_id
   clusters <- cluster_df[rownames(pca_matrix),]$cluster
-
-  # check that we have the right number of clusters after ensuring correct order
-  stopifnot(
-    "Could not extract clusters from cluster_df due to mismatch with PCA matrix." =
-      !any(is.na(clusters))
-  )
 
   # calculate ARI for each cluster result bootstrap replicate
   all_ari_df <- 1:replicates |>

--- a/man/calculate_stability.Rd
+++ b/man/calculate_stability.Rd
@@ -6,7 +6,7 @@
 \usage{
 calculate_stability(
   x,
-  clusters,
+  cluster_df,
   replicates = 20,
   seed = NULL,
   pc_name = NULL,
@@ -19,8 +19,10 @@ either a SingleCellExperiment object, a Seurat object, or a matrix where columns
 are PCs and rows are cells. If a matrix is provided, it must have row names of cell
 ids (e.g., barcodes).}
 
-\item{clusters}{A vector of cluster ids, typically a numeric factor variable, obtained
-by previously clustering the PCs.}
+\item{cluster_df}{A data frame that contains at least the columns `cell_id` and
+`cluster`. The `cell_id` values should match either the PC matrix row names,
+or the SingleCellExperiment/Seurat object cell ids. Typically this will be output from
+the `rOpenScPCA::calculate_clusters()` function.}
 
 \item{replicates}{Number of bootstrap replicates to perform. Default is 20.}
 
@@ -64,7 +66,7 @@ to "jaccard" to align with common practice in scRNA-seq analysis.
 # and setting a seed for reproducibility
 cluster_df <- calculate_clusters(sce_object, seed = 11)
 # Second, calculate cluster stability using default parameters
-stability_df <- calculate_stability(sce_object, cluster_df$clusters, seed = 11)
+stability_df <- calculate_stability(sce_object, cluster_df, seed = 11)
 
 
 # First, cluster PCs from a SingleCellExperiment object using default parameters
@@ -73,7 +75,7 @@ cluster_df <- calculate_clusters(sce_object, seed = 11)
 # Second, calculate cluster stability using default parameters and 50 replicates
 stability_df <- calculate_stability(
   sce_object,
-  cluster_df$clusters,
+  cluster_df,
   replicates = 50,
   seed = 11
 )
@@ -91,7 +93,7 @@ cluster_df <- calculate_clusters(
 # for the initial clustering
 stability_df <- calculate_stability(
   sce_object,
-  cluster_df$clusters,
+  cluster_df,
   algorithm = "leiden",
   resolution = 0.1,
   seed = 11

--- a/tests/testthat/test-evaluate-clusters.R
+++ b/tests/testthat/test-evaluate-clusters.R
@@ -45,7 +45,7 @@ test_that("calculate_stability works as expected with defaults", {
   # note that we suppress warnings since this calculation done on fake
   # test data gives expected warnings about ties during the ARI calculation.
   suppressWarnings({
-    df <- calculate_stability(test_mat, cluster_df$cluster)
+    df <- calculate_stability(test_mat, cluster_df)
   })
 
   expected_names <- colnames(cluster_df)[!(colnames(cluster_df) %in% c("cell_id", "cluster"))]
@@ -62,7 +62,7 @@ test_that("calculate_stability works as expected with different replicates", {
   # note that we suppress warnings since this calculation done on fake
   # test data gives expected warnings about ties during the ARI calculation.
   suppressWarnings({
-    df <- calculate_stability(test_mat, cluster_df$cluster, replicates = 2)
+    df <- calculate_stability(test_mat, cluster_df, replicates = 2)
   })
   expect_equal(nrow(df), 2)
 })
@@ -77,7 +77,7 @@ test_that("calculate_stability works as expected with object and pc_name", {
   suppressWarnings({
     df <- calculate_stability(
       sce,
-      cluster_df$cluster,
+      cluster_df,
       replicates = 2,
       pc_name = "my_pca"
     )
@@ -90,11 +90,6 @@ test_that("calculate_stability works as expected with object and pc_name", {
 test_that("calculate_stability errors as expected", {
   expect_error({
     # mismatched cluster vector length
-    calculate_stability(test_mat, cluster_df$cluster[1:5])
-  })
-
-  expect_error({
-    # cluster_df not a vector
-    calculate_stability(test_mat, cluster_df)
+    calculate_stability(test_mat, cluster_df[1:5,])
   })
 })

--- a/tests/testthat/test-evaluate-clusters.R
+++ b/tests/testthat/test-evaluate-clusters.R
@@ -88,8 +88,16 @@ test_that("calculate_stability works as expected with object and pc_name", {
 
 
 test_that("calculate_stability errors as expected", {
+
+  # cluster_df too short
   expect_error({
-    # mismatched cluster vector length
     calculate_stability(test_mat, cluster_df[1:5,])
+  })
+
+  # cluster_df too long
+  cluster_df_extra <- cluster_df |>
+    tibble::add_row(cell_id = "extra_barcode")
+  expect_error({
+    calculate_stability(test_mat, cluster_df_extra)
   })
 })


### PR DESCRIPTION
Closes #3 

This PR updates the `calculate_stability` function to take a data frame instead of a vector of cluster ids. This allows us to confirm the provided clusters are in the correct order for subsequent calculations. 
Let me know if there's any tests you think I should add! I did remove one test checking that a data frame _wasn't passed in_, since that didn't seem necessary anymore now that all evaluation functions take a data frame.

Once this goes in, I will go update the code in the `cell-type-ETP-ALL-03` and `cell-type-nonETP-ALL-03` that uses this function to take the data frame, not just the vector. Edit: I opened that issue here https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/870