### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/R-CMD-CHECK-release.yml
+++ b/.github/workflows/R-CMD-CHECK-release.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - feature/*
-  pull_request:
-
 name: R-CMD-CHECK-release
 
 jobs:

--- a/.github/workflows/R-CMD-CHECK-release.yml
+++ b/.github/workflows/R-CMD-CHECK-release.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Remove renv so environment will not be overridden
+        run: rm -f renv.lock .Rprofile
+
       - name: Set up dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-CHECK-release.yml
+++ b/.github/workflows/R-CMD-CHECK-release.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - main
       - feature/*
+  pull_request:
 
 name: R-CMD-CHECK-release
 
 jobs:
-  R-CMD-check-renv:
+  R-CMD-check-release:
     runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,11 +28,13 @@ RoxygenNote: 7.3.2
 Imports:
     BiocParallel,
     bluster (>= 1.14),
+    DelayedMatrixStats,
     dplyr,
     methods,
     pdfCluster,
     purrr,
     SingleCellExperiment,
+    sparseMatrixStats,
     tibble,
     tidyr
 biocViews:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,13 +28,11 @@ RoxygenNote: 7.3.2
 Imports:
     BiocParallel,
     bluster (>= 1.14),
-    DelayedMatrixStats,
     dplyr,
     methods,
     pdfCluster,
     purrr,
     SingleCellExperiment,
-    sparseMatrixStats,
     tibble,
     tidyr
 biocViews:


### PR DESCRIPTION
I'm filing this PR to fix the failure of the release GHA which runs on pulls (noting the job was misnamed as `renv`, but this is indeed the release GHA): https://github.com/AlexsLemonade/rOpenScPCA/actions/runs/11805537264/job/32888217441.

Opening as a draft to get this passing before requesting review.