### PR TITLE
Add rowData to summed SCE output

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,4 +6,5 @@
 ^\.lintr$
 ^\.pre-commit-config.yaml$
 ^data-raw$
+^dependencies.R$
 ^LICENSE\.md$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,7 @@ repos:
       - id: no-debug-statement
       - id: deps-in-desc
         exclude: 'docker/.*|renv/.*|data-raw/.*'
+
+ci:
+  autofix_prs: true
+  autoupdate_schedule: quarterly

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Suggests:
     scran,
     Seurat,
     splatter,
-    scuttle,
     Matrix,
     SeuratObject
 Config/testthat/edition: 3
@@ -37,6 +36,7 @@ Imports:
     pdfCluster,
     purrr,
     S4Vectors,
+    scuttle,
     SingleCellExperiment,
     SummarizedExperiment,
     tibble,

--- a/dependencies.R
+++ b/dependencies.R
@@ -1,0 +1,3 @@
+# development dependencies for renv
+
+library("devtools")

--- a/man/sum_duplicate_genes.Rd
+++ b/man/sum_duplicate_genes.Rd
@@ -30,6 +30,11 @@ substantial sequence identity, which could make separate quantification of
 the two genes less reliable.
 }
 \details{
+The rowData for the summed SingleCellExperiment object is updated to reflect
+the new set of gene names. In each case, the first row for any duplicated id
+is retained. This may mean that for gene symbols that correspond to multiple
+Ensembl ids, the first Ensembl id is retained and the others are dropped.
+
 If requested, the log-normalized expression values are recalculated,
 otherwise that matrix is left blank.
 

--- a/renv.lock
+++ b/renv.lock
@@ -909,6 +909,13 @@
       ],
       "Hash": "ed9597168d850071aa9abbbef7be7204"
     },
+    "brew": {
+      "Package": "brew",
+      "Version": "1.0-10",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8f4a384e19dccd8c65356dc096847b76"
+    },
     "brio": {
       "Package": "brio",
       "Version": "1.1.5",
@@ -1166,6 +1173,40 @@
       ],
       "Hash": "99b79fcbd6c4d1ce087f5c5c758b384f"
     },
+    "devtools": {
+      "Package": "devtools",
+      "Version": "2.4.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "desc",
+        "ellipsis",
+        "fs",
+        "lifecycle",
+        "memoise",
+        "miniUI",
+        "pkgbuild",
+        "pkgdown",
+        "pkgload",
+        "profvis",
+        "rcmdcheck",
+        "remotes",
+        "rlang",
+        "roxygen2",
+        "rversions",
+        "sessioninfo",
+        "stats",
+        "testthat",
+        "tools",
+        "urlchecker",
+        "usethis",
+        "utils",
+        "withr"
+      ],
+      "Hash": "ea5bc8b4a6a01e4f12d98b58329930bb"
+    },
     "diffobj": {
       "Package": "diffobj",
       "Version": "0.3.5",
@@ -1201,6 +1242,26 @@
         "R"
       ],
       "Hash": "80f374ef8500fcdc5d84a0345b837227"
+    },
+    "downlit": {
+      "Package": "downlit",
+      "Version": "0.4.4",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "brio",
+        "desc",
+        "digest",
+        "evaluate",
+        "fansi",
+        "memoise",
+        "rlang",
+        "vctrs",
+        "withr",
+        "yaml"
+      ],
+      "Hash": "45a6a596bf0108ee1ff16a040a2df897"
     },
     "dplyr": {
       "Package": "dplyr",
@@ -1254,6 +1315,17 @@
         "utils"
       ],
       "Hash": "729daec53b663926458ccde421f5c2fb"
+    },
+    "ellipsis": {
+      "Package": "ellipsis",
+      "Version": "0.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "rlang"
+      ],
+      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -2238,6 +2310,36 @@
       ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
+    "pkgdown": {
+      "Package": "pkgdown",
+      "Version": "2.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "bslib",
+        "callr",
+        "cli",
+        "desc",
+        "digest",
+        "downlit",
+        "fontawesome",
+        "fs",
+        "httr2",
+        "jsonlite",
+        "openssl",
+        "purrr",
+        "ragg",
+        "rlang",
+        "rmarkdown",
+        "tibble",
+        "whisker",
+        "withr",
+        "xml2",
+        "yaml"
+      ],
+      "Hash": "df2912d5873422b55a13002510f02c9f"
+    },
     "pkgload": {
       "Package": "pkgload",
       "Version": "1.4.0",
@@ -2330,6 +2432,16 @@
       "Repository": "CRAN",
       "Hash": "a555924add98c99d2f411e37e7d25e9f"
     },
+    "prettyunits": {
+      "Package": "prettyunits",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "6b01fc98b1e86c4f705ce9dcfd2f57c7"
+    },
     "processx": {
       "Package": "processx",
       "Version": "3.8.4",
@@ -2342,6 +2454,19 @@
         "utils"
       ],
       "Hash": "0c90a7d71988856bad2a2a45dd871bb9"
+    },
+    "profvis": {
+      "Package": "profvis",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "htmlwidgets",
+        "rlang",
+        "vctrs"
+      ],
+      "Hash": "bffa126bf92987e677c12cfb5651fc1d"
     },
     "progressr": {
       "Package": "progressr",
@@ -2418,12 +2543,51 @@
       ],
       "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
     },
+    "rcmdcheck": {
+      "Package": "rcmdcheck",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R6",
+        "callr",
+        "cli",
+        "curl",
+        "desc",
+        "digest",
+        "pkgbuild",
+        "prettyunits",
+        "rprojroot",
+        "sessioninfo",
+        "utils",
+        "withr",
+        "xopen"
+      ],
+      "Hash": "8f25ebe2ec38b1f2aef3b0d2ef76f6c4"
+    },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "stats",
+        "tools",
+        "utils"
+      ],
+      "Hash": "3ee025083e66f18db6cf27b56e23e141"
+    },
     "renv": {
       "Package": "renv",
       "Version": "1.0.11",
-      "OS_type": null,
-      "Repository": "CRAN",
-      "Source": "Repository"
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "47623f66b4e80b3b0587bc5d7b309888"
     },
     "reshape2": {
       "Package": "reshape2",
@@ -2517,6 +2681,32 @@
       ],
       "Hash": "062470668513dcda416927085ee9bdc7"
     },
+    "roxygen2": {
+      "Package": "roxygen2",
+      "Version": "7.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "brew",
+        "cli",
+        "commonmark",
+        "cpp11",
+        "desc",
+        "knitr",
+        "methods",
+        "pkgload",
+        "purrr",
+        "rlang",
+        "stringi",
+        "stringr",
+        "utils",
+        "withr",
+        "xml2"
+      ],
+      "Hash": "6ee25f9054a70f44d615300ed531ba8d"
+    },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "2.0.4",
@@ -2544,6 +2734,18 @@
         "R"
       ],
       "Hash": "b462187d887abc519894874486dbd6fd"
+    },
+    "rversions": {
+      "Package": "rversions",
+      "Version": "2.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "curl",
+        "utils",
+        "xml2"
+      ],
+      "Hash": "a9881dfed103e83f9de151dc17002cd1"
     },
     "sass": {
       "Package": "sass",
@@ -2706,6 +2908,19 @@
         "utils"
       ],
       "Hash": "6d94b72071aefd6e8b041c34ee83ebd0"
+    },
+    "sessioninfo": {
+      "Package": "sessioninfo",
+      "Version": "1.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "tools",
+        "utils"
+      ],
+      "Hash": "3f9796a8d0a0e8c6eb49a4b029359d1f"
     },
     "shiny": {
       "Package": "shiny",
@@ -3158,6 +3373,20 @@
       ],
       "Hash": "cfbad971a71f0e27cec22e544a08bc3b"
     },
+    "urlchecker": {
+      "Package": "urlchecker",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "curl",
+        "tools",
+        "xml2"
+      ],
+      "Hash": "409328b8e1253c8d729a7836fe7f7a16"
+    },
     "usethis": {
       "Package": "usethis",
       "Version": "3.0.0",
@@ -3312,6 +3541,30 @@
         "tools"
       ],
       "Hash": "36ab21660e2d095fef0d83f689e0477c"
+    },
+    "xml2": {
+      "Package": "xml2",
+      "Version": "1.3.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "methods",
+        "rlang"
+      ],
+      "Hash": "1d0336142f4cd25d8d23cd3ba7a8fb61"
+    },
+    "xopen": {
+      "Package": "xopen",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "processx"
+      ],
+      "Hash": "423df1e86d5533fcb73c6b02b4923b49"
     },
     "xtable": {
       "Package": "xtable",

--- a/tests/testthat/test-sum-duplicate-genes.R
+++ b/tests/testthat/test-sum-duplicate-genes.R
@@ -5,7 +5,14 @@ test_that("merging works as expected", {
 
   expect_equal(dim(deduped_sce), dim(sce))
 
-  expect_setequal(rownames(deduped_sce), rownames(sce))
+  expect_equal(rownames(deduped_sce), rownames(sce))
+
+  expect_contains(
+    colnames(rowData(deduped_sce)),
+    c("gene_ids", "gene_symbol", "mean", "detected")
+  )
+  expect_equal(rowData(deduped_sce)$gene_ids, rowData(sce)$gene_ids)
+  expect_equal(rowData(deduped_sce)$gene_symbol, rowData(sce)$gene_symbol)
 
 
   expect_equal(
@@ -25,7 +32,14 @@ test_that("merging works as expected with unprocessed SCE", {
 
   expect_equal(dim(deduped_sce), dim(sce))
 
-  expect_setequal(rownames(deduped_sce), rownames(sce))
+  expect_equal(rownames(deduped_sce), rownames(sce))
+
+  expect_contains(
+    colnames(rowData(deduped_sce)),
+    c("gene_ids", "gene_symbol", "mean", "detected")
+  )
+  expect_equal(rowData(deduped_sce)$gene_ids, rowData(sce)$gene_ids)
+  expect_equal(rowData(deduped_sce)$gene_symbol, rowData(sce)$gene_symbol)
 
 
   expect_equal(


### PR DESCRIPTION
I realized in testing that we had lost the rowData when summing SCE objects over duplicated features, so this PR adds those back. 

I am currently using just the first row encountered in the case of duplicates, which I think is fine for most cases, as it will keep things consistent. I just had a thought that we could instead use the id with the greatest expression, but that could results in different translations for different objects, which seemed not so great. So I left it as just the first. I also considered concatenation, but that seemed too messy, again for little gain. 

Following #19, I also added `devtools` to `renv` here for developer convenience. I also added a few updates to pre-commit so it doesn't bother us with update PRs so often. 