### PR TITLE
Handle large matrices and change default Seurat format

### DIFF
--- a/R/make-seurat.R
+++ b/R/make-seurat.R
@@ -120,12 +120,12 @@ sce_to_seurat <- function(
   }
 
   # convert and set functions depending on assay version requested
-  if (seurat_assay_version == "v5") {
-    create_seurat_assay <- SeuratObject::CreateAssay5Object
-    suppressWarnings(sobj[["RNA"]] <- as(sobj[["RNA"]], "Assay5"))
-  } else {
+  if (seurat_assay_version == "v3") {
     create_seurat_assay <- SeuratObject::CreateAssayObject
     suppressWarnings(sobj[["RNA"]] <- as(sobj[["RNA"]], "Assay"))
+  } else {
+    create_seurat_assay <- SeuratObject::CreateAssay5Object
+    suppressWarnings(sobj[["RNA"]] <- as(sobj[["RNA"]], "Assay5"))
   }
 
   # add spliced data if present

--- a/R/make-seurat.R
+++ b/R/make-seurat.R
@@ -20,8 +20,8 @@
 #' @param dedup_method Method to handle duplicated gene symbols. If `unique`,
 #'   the gene symbols will be made unique following standard Seurat procedures.
 #'   If `sum`, the expression values for each gene symbols will be summed.
-#' @param seurat_assay_version Whether to create Seurat `v3` or `v5` assay
-#'   objects. Default is `v3`.
+#' @param seurat_assay_version Whether to create Seurat `v5` or `v3` assay
+#'   objects. Default is `v5`.
 #'
 #' @return a Seurat object
 #' @export
@@ -37,8 +37,8 @@
 #' # convert SCE to Seurat, merging duplicated gene names
 #' seurat_obj <- sce_to_seurat(sce, dedup_method = "sum")
 #'
-#' # convert SCE to Seurat with v5 assay objects
-#' seurat_obj <- sce_to_seurat(sce, seurat_assay_version = "v5")
+#' # convert SCE to Seurat with v3 assay objects
+#' seurat_obj <- sce_to_seurat(sce, seurat_assay_version = "v3")
 #' }
 #'
 sce_to_seurat <- function(
@@ -46,7 +46,7 @@ sce_to_seurat <- function(
     use_symbols = TRUE,
     reference = c("sce", "scpca", "10x2020", "10x2024"),
     dedup_method = c("unique", "sum"),
-    seurat_assay_version = c("v3", "v5")) {
+    seurat_assay_version = c("v5", "v3")) {
   reference <- match.arg(reference)
   dedup_method <- match.arg(dedup_method)
   seurat_assay_version <- match.arg(seurat_assay_version)

--- a/man/sce_to_seurat.Rd
+++ b/man/sce_to_seurat.Rd
@@ -9,7 +9,7 @@ sce_to_seurat(
   use_symbols = TRUE,
   reference = c("sce", "scpca", "10x2020", "10x2024"),
   dedup_method = c("unique", "sum"),
-  seurat_assay_version = c("v3", "v5")
+  seurat_assay_version = c("v5", "v3")
 )
 }
 \arguments{
@@ -28,8 +28,8 @@ for more information. Default is `sce`.}
 the gene symbols will be made unique following standard Seurat procedures.
 If `sum`, the expression values for each gene symbols will be summed.}
 
-\item{seurat_assay_version}{Whether to create Seurat `v3` or `v5` assay
-objects. Default is `v3`.}
+\item{seurat_assay_version}{Whether to create Seurat `v5` or `v3` assay
+objects. Default is `v5`.}
 }
 \value{
 a Seurat object
@@ -55,8 +55,8 @@ seurat_obj <- sce_to_seurat(sce, use_symbols = FALSE)
 # convert SCE to Seurat, merging duplicated gene names
 seurat_obj <- sce_to_seurat(sce, dedup_method = "sum")
 
-# convert SCE to Seurat with v5 assay objects
-seurat_obj <- sce_to_seurat(sce, seurat_assay_version = "v5")
+# convert SCE to Seurat with v3 assay objects
+seurat_obj <- sce_to_seurat(sce, seurat_assay_version = "v3")
 }
 
 }

--- a/tests/testthat/test-make-seurat.R
+++ b/tests/testthat/test-make-seurat.R
@@ -11,13 +11,14 @@ test_that("SCE to Seurat with no id conversion works", {
   expect_equal(Seurat::DefaultAssay(seurat_obj), "RNA")
 
   # assay types
-  expect_s4_class(seurat_obj[["RNA"]], "Assay")
-  expect_s4_class(seurat_obj[["spliced"]], "Assay")
+  expect_s4_class(seurat_obj[["RNA"]], "Assay5")
+  expect_s4_class(seurat_obj[["spliced"]], "Assay5")
 
-  # assay contents
+
+  # expected layers present
   expect_contains(
-    slotNames(seurat_obj[["RNA"]]),
-    c("counts", "data", "scale.data", "var.features", "meta.features")
+    names(seurat_obj[["RNA"]]@layers),
+    c("counts", "data", "scale.data")
   )
 
   expect_equal(seurat_obj[["RNA"]]$counts, counts(sce))
@@ -66,13 +67,13 @@ test_that("SCE to Seurat with id conversion works as expected", {
   expect_equal(Seurat::DefaultAssay(seurat_obj), "RNA")
 
   # assay types
-  expect_s4_class(seurat_obj[["RNA"]], "Assay")
-  expect_s4_class(seurat_obj[["spliced"]], "Assay")
+  expect_s4_class(seurat_obj[["RNA"]], "Assay5")
+  expect_s4_class(seurat_obj[["spliced"]], "Assay5")
 
-  # assay contents
+  # expected layers present
   expect_contains(
-    slotNames(seurat_obj[["RNA"]]),
-    c("counts", "data", "scale.data", "var.features", "meta.features")
+    names(seurat_obj[["RNA"]]@layers),
+    c("counts", "data", "scale.data")
   )
 
   expect_equal(
@@ -116,13 +117,13 @@ test_that("SCE to Seurat with id conversion and 10x reference works as expected"
 
 
   # assay types
-  expect_s4_class(seurat_obj[["RNA"]], "Assay")
-  expect_s4_class(seurat_obj[["spliced"]], "Assay")
+  expect_s4_class(seurat_obj[["RNA"]], "Assay5")
+  expect_s4_class(seurat_obj[["spliced"]], "Assay5")
 
-  # assay contents
+  # expected layers present
   expect_contains(
-    slotNames(seurat_obj[["RNA"]]),
-    c("counts", "data", "scale.data", "var.features", "meta.features")
+    names(seurat_obj[["RNA"]]@layers),
+    c("counts", "data", "scale.data")
   )
 
   expect_equal(
@@ -163,15 +164,15 @@ test_that("conversion works with altExps", {
   expect_equal(Seurat::DefaultAssay(seurat_obj), "RNA")
 
   # assay types
-  expect_s4_class(seurat_obj[["RNA"]], "Assay")
-  expect_s4_class(seurat_obj[["spliced"]], "Assay")
-  expect_s4_class(seurat_obj[["alt1"]], "Assay")
-  expect_s4_class(seurat_obj[["alt2"]], "Assay")
+  expect_s4_class(seurat_obj[["RNA"]], "Assay5")
+  expect_s4_class(seurat_obj[["spliced"]], "Assay5")
+  expect_s4_class(seurat_obj[["alt1"]], "Assay5")
+  expect_s4_class(seurat_obj[["alt2"]], "Assay5")
 })
 
-test_that("Seurat v5 conversion works", {
+test_that("Seurat v3 conversion works", {
   sce <- readRDS(test_path("data", "scpca_sce.rds"))
-  seurat_obj <- sce_to_seurat(sce, use_symbols = FALSE, seurat_assay_version = "v5")
+  seurat_obj <- sce_to_seurat(sce, use_symbols = FALSE, seurat_assay_version = "v3")
   expect_s4_class(seurat_obj, "Seurat")
 
   expect_equal(dim(seurat_obj), dim(sce))
@@ -182,13 +183,13 @@ test_that("Seurat v5 conversion works", {
   expect_equal(Seurat::DefaultAssay(seurat_obj), "RNA")
 
   # assay types
-  expect_s4_class(seurat_obj[["RNA"]], "Assay5")
-  expect_s4_class(seurat_obj[["spliced"]], "Assay5")
+  expect_s4_class(seurat_obj[["RNA"]], "Assay")
+  expect_s4_class(seurat_obj[["spliced"]], "Assay")
 
-  # expected layers present
+  # assay contents
   expect_contains(
-    names(seurat_obj[["RNA"]]@layers),
-    c("counts", "data", "scale.data")
+    slotNames(seurat_obj[["RNA"]]),
+    c("counts", "data", "scale.data", "var.features")
   )
 
   expect_equal(seurat_obj[["RNA"]]$counts, counts(sce))
@@ -224,13 +225,13 @@ test_that("Conversion works for non-processed samples", {
   expect_equal(Seurat::DefaultAssay(seurat_obj), "RNA")
 
   # assay types
-  expect_s4_class(seurat_obj[["RNA"]], "Assay")
-  expect_s4_class(seurat_obj[["spliced"]], "Assay")
+  expect_s4_class(seurat_obj[["RNA"]], "Assay5")
+  expect_s4_class(seurat_obj[["spliced"]], "Assay5")
 
-  # assay contents
+  # expected layers present
   expect_contains(
-    slotNames(seurat_obj[["RNA"]]),
-    c("counts", "data", "scale.data", "var.features", "meta.features")
+    names(seurat_obj[["RNA"]]@layers),
+    c("counts", "data", "scale.data")
   )
 
   expect_equal(seurat_obj[["RNA"]]$counts, counts(sce))

--- a/tests/testthat/test-sum-duplicate-genes.R
+++ b/tests/testthat/test-sum-duplicate-genes.R
@@ -6,6 +6,7 @@ test_that("merging works as expected", {
   expect_equal(dim(deduped_sce), dim(sce))
 
   expect_equal(rownames(deduped_sce), rownames(sce))
+  expect_equal(colnames(deduped_sce), colnames(sce))
 
   expect_contains(
     colnames(rowData(deduped_sce)),
@@ -33,6 +34,7 @@ test_that("merging works as expected with unprocessed SCE", {
   expect_equal(dim(deduped_sce), dim(sce))
 
   expect_equal(rownames(deduped_sce), rownames(sce))
+  expect_equal(colnames(deduped_sce), colnames(sce))
 
   expect_contains(
     colnames(rowData(deduped_sce)),


### PR DESCRIPTION
When testing https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/953, I found that the sum counts function doesn't work with very large matrices, namely unfiltered matrices. We probably don't really need to support that, but it wasn't too hard to do, so I added a bit of splitting and merging to avoid ever creating a single very large non-sparse matrix. 

(There was a fun edge case I ran into when the matrix was one larger than a multiple of the chunk size...)

After some more `Seurat` testing, I also discovered that `v5` is really the default for new objects, so we might as well make that our default too. So there are bunch of test changes related to that change in defaults. 