### PR TITLE
Address circumstances with only 1 cluster

### DIFF
--- a/R/evaluate-clusters.R
+++ b/R/evaluate-clusters.R
@@ -59,7 +59,7 @@ calculate_silhouette <- function(
 
   silhouette_df <- x |>
     prepare_pc_matrix(pc_name) |>
-    bluster::approxSilhouette(cluster_df[[cluster_col]])
+    bluster::approxSilhouette(cluster_df[[cluster_col]]) |>
     as.data.frame() |>
     # note this gets renamed later as needed
     tibble::rownames_to_column("cell_id") |>

--- a/R/evaluate-clusters.R
+++ b/R/evaluate-clusters.R
@@ -25,8 +25,9 @@
 #'   the cell's silhouette width, and `silhouette_other`, the closest cluster other
 #'   than the one to which the given cell was assigned. For more information,
 #'   see documentation for `bluster::approxSilhouette()`.
-#'   If there is only one cluster in the provided data, silhouette width will not be
-#'   calculated, and the inputted `cluster_df` data frame will be returned.
+#'   If there is only one cluster in the provided data, silhouette width can not be
+#'   calculated. The returned data frame will have `NA` values in the
+#'   `silhouette_width` and `silhouette_other` columns.
 #'
 #' @importFrom stats setNames
 #'
@@ -52,6 +53,11 @@ calculate_silhouette <- function(
 
   if (length(unique(cluster_df[[cluster_col]])) == 1) {
     warning("There is only 1 cluster in this data. Silhouette width will not be calculated.")
+    cluster_df <- cluster_df |>
+      dplyr::mutate(
+        silhouette_width = NA,
+        silhouette_other = NA
+      )
     return(cluster_df)
   }
 
@@ -105,8 +111,9 @@ calculate_silhouette <- function(
 #'   the cell's neighborhood purity, and `maximum_neighbor`, the cluster with the
 #'   highest proportion of observations neighboring the given cell. For more
 #'   information see documentation for `bluster::neighborPurity()`.
-#'   If there is only one cluster in the provided data, neighborhood purity will not be
-#'   calculated, and the inputted `cluster_df` data frame will be returned.
+#'   If there is only one cluster in the provided data, neighborhood purity can not be
+#'   calculated. The returned data frame will have `NA` values in the `purity` and
+#'   `maximum_neighbor` columns.
 #'
 #' @export
 #' @examples
@@ -131,6 +138,11 @@ calculate_purity <- function(
 
   if (length(unique(cluster_df[[cluster_col]])) == 1) {
     warning("There is only 1 cluster in this data. Neighborhood purity will not be calculated.")
+    cluster_df <- cluster_df |>
+      dplyr::mutate(
+        purity = NA,
+        maximum_neighbor = NA
+      )
     return(cluster_df)
   }
 

--- a/R/evaluate-clusters.R
+++ b/R/evaluate-clusters.R
@@ -42,7 +42,6 @@ calculate_silhouette <- function(
     cluster_col = "cluster",
     cell_id_col = "cell_id",
     pc_name = NULL) {
-
   expected_df_names <- c(cell_id_col, cluster_col)
   stopifnot(
     "The cell id column name must be length of 1." = length(cell_id_col) == 1,
@@ -122,7 +121,6 @@ calculate_purity <- function(
     cell_id_col = "cell_id",
     pc_name = NULL,
     ...) {
-
   expected_df_names <- c(cell_id_col, cluster_col)
   stopifnot(
     "The cell id column name must be length of 1." = length(cell_id_col) == 1,

--- a/R/evaluate-clusters.R
+++ b/R/evaluate-clusters.R
@@ -25,6 +25,8 @@
 #'   the cell's silhouette width, and `silhouette_other`, the closest cluster other
 #'   than the one to which the given cell was assigned. For more information,
 #'   see documentation for `bluster::approxSilhouette()`.
+#'   If there is only one cluster in the provided data, silhouette width will not be
+#'   calculated, and the inputted `cluster_df` data frame will be returned.
 #'
 #' @importFrom stats setNames
 #'
@@ -40,7 +42,6 @@ calculate_silhouette <- function(
     cluster_col = "cluster",
     cell_id_col = "cell_id",
     pc_name = NULL) {
-  x <- prepare_pc_matrix(x, pc_name)
 
   expected_df_names <- c(cell_id_col, cluster_col)
   stopifnot(
@@ -50,8 +51,15 @@ calculate_silhouette <- function(
       all(expected_df_names %in% colnames(cluster_df))
   )
 
+  if (length(unique(cluster_df[[cluster_col]])) == 1) {
+    warning("There is only 1 cluster in this data. Silhouette width will not be calculated.")
+    return(cluster_df)
+  }
+
+
   silhouette_df <- x |>
-    bluster::approxSilhouette(cluster_df[[cluster_col]]) |>
+    prepare_pc_matrix(pc_name) |>
+    bluster::approxSilhouette(cluster_df[[cluster_col]])
     as.data.frame() |>
     # note this gets renamed later as needed
     tibble::rownames_to_column("cell_id") |>
@@ -98,6 +106,8 @@ calculate_silhouette <- function(
 #'   the cell's neighborhood purity, and `maximum_neighbor`, the cluster with the
 #'   highest proportion of observations neighboring the given cell. For more
 #'   information see documentation for `bluster::neighborPurity()`.
+#'   If there is only one cluster in the provided data, neighborhood purity will not be
+#'   calculated, and the inputted `cluster_df` data frame will be returned.
 #'
 #' @export
 #' @examples
@@ -112,7 +122,6 @@ calculate_purity <- function(
     cell_id_col = "cell_id",
     pc_name = NULL,
     ...) {
-  x <- prepare_pc_matrix(x, pc_name)
 
   expected_df_names <- c(cell_id_col, cluster_col)
   stopifnot(
@@ -122,7 +131,13 @@ calculate_purity <- function(
       all(expected_df_names %in% colnames(cluster_df))
   )
 
+  if (length(unique(cluster_df[[cluster_col]])) == 1) {
+    warning("There is only 1 cluster in this data. Neighborhood purity will not be calculated.")
+    return(cluster_df)
+  }
+
   purity_df <- x |>
+    prepare_pc_matrix(pc_name) |>
     bluster::neighborPurity(cluster_df[[cluster_col]], ...) |>
     as.data.frame() |>
     tibble::rownames_to_column(cell_id_col) |>

--- a/tests/testthat/test-evaluate-clusters.R
+++ b/tests/testthat/test-evaluate-clusters.R
@@ -48,6 +48,19 @@ test_that("calculate_silhouette works as expected with non-default cell id colum
 
 
 
+test_that("calculate_silhouette throws a warning when there is only 1 cluster", {
+  cluster_df <- cluster_df |>
+    dplyr::mutate(cluster = 1)
+
+  expect_warning({
+    df <- calculate_silhouette(test_mat, cluster_df)
+  })
+
+  expect_equal(cluster_df, df)
+})
+
+
+
 test_that("calculate_purity works as expected", {
   df <- calculate_purity(test_mat, cluster_df)
 
@@ -88,6 +101,18 @@ test_that("calculate_purity works as expected with non-default cell id column na
     c(colnames(cluster_df), "purity", "maximum_neighbor")
   )
   expect_equal(df$cluster, cluster_df$cluster)
+})
+
+
+test_that("calculate_purity throws a warning when there is only 1 cluster", {
+  cluster_df <- cluster_df |>
+    dplyr::mutate(cluster = 1)
+
+  expect_warning({
+    df <- calculate_purity(test_mat, cluster_df)
+  })
+
+  expect_equal(cluster_df, df)
 })
 
 

--- a/tests/testthat/test-evaluate-clusters.R
+++ b/tests/testthat/test-evaluate-clusters.R
@@ -56,7 +56,12 @@ test_that("calculate_silhouette throws a warning when there is only 1 cluster", 
     df <- calculate_silhouette(test_mat, cluster_df)
   })
 
-  expect_equal(cluster_df, df)
+  expected_output <- cluster_df |>
+    dplyr::mutate(
+      silhouette_width = NA,
+      silhouette_other = NA
+    )
+  expect_equal(expected_output, df)
 })
 
 
@@ -112,7 +117,12 @@ test_that("calculate_purity throws a warning when there is only 1 cluster", {
     df <- calculate_purity(test_mat, cluster_df)
   })
 
-  expect_equal(cluster_df, df)
+  expected_output <- cluster_df |>
+    dplyr::mutate(
+      purity = NA,
+      maximum_neighbor = NA
+    )
+  expect_equal(expected_output, df)
 })
 
 


### PR DESCRIPTION
Closes #22 

At long last, we have been forced to address this issue!

In this PR, I'm updating just the silhouette and purity functions to throw a warning if there is only 1 cluster. I then return the inputted data frame directly. This was a choice I went back and forth on; specifically, I was considering returning a stat column with all `NA`s as well, but then I talked myself out of it because I don't want that to appear as though the calculation was tried and failed. The calculation just doesn't happen (because bluster will fail). Care to talk me back into it, or talk me into something else? That said, read on!

I did not, however, touch the stability function only because it won't technically fail, although the ari's will of course all be 0. I'm certainly open to changing something here though, for example...
- if there's 1 cluster, don't bother doing any calculations since we know the answer
- also throw and warning and don't attempt to calculate, not because of a bug but because it doesn't make much sense to calculate anything 

Notably, this is all kind of different from what's in the linked issue (see the short-lived #34 I opened today before I was reminded #22 exists!). I don't feel too tied to _any_ of these approaches honestly, in large part because I'm not sure how much these functions realistically will get used moving forward. So, I chose to make the changes I made in this PR b/c it was the quickest path to getting the functions running bug-free. That said, of course open to implementation feedback and doing more interesting things!